### PR TITLE
Setup for publishing to Sonatype's Central Portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build
 
 # IntelliJ
 .idea/
+
+# Vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-# wherobots-jdbc-driver
-JDBC Driver Implementation for the Wherobots Spatial SQL API
+# Wherobots Spatial SQL JDBC Driver
+
+This library provides a JDBC driver implementation for the Wherobots
+Spatial SQL API. It allows you to build Java/Scala/Kotlin applications
+that can interact with Wherobots and leverage the Spatial SQL and
+geospatial analytics capabilities of WherobotsDB.
+
+This JDBC driver is also directly usable from database applications like
+JetBrains's DataGrip or DBeaver.
+
+## Usage
+
+### As a library
+
+```gradle
+dependencies {
+  implementation 'com.wherobots.jdbc:wherobots-jdbc-driver:0.1.0'
+}
+```
+
+### In DataGrip
+
+TODO: add instructions for configuring a database connection with the
+Wherobots JDBC driver.
+
+## Release
+
+To publish a new release, you need an account on [Sonatype's Central
+Portal](https://central.sonatype.com) with permissions to publish into
+the `com.wherobots` namespace. From your account, create an API key,
+which gets you a user token and secret key pair:
+
+```sh
+export OSSRH_USERNAME=<user token>
+export OSSRH_PASSWORD=<secret key>
+```
+
+You also need a GnuPG key, loaded up in `gpg-agent`, for signing the
+release artifacts.
+
+Then, after setting the new version in `lib/build.gradle`, publish with:
+
+```sh
+$ ./gradlew clean publishToCentralPortal
+```
+
+You can then check the status and validation of thsi deployment at
+https://central.sonatype.com/publishing/deployments

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,3 @@
 
 org.gradle.parallel=true
 org.gradle.caching=true
-

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,13 +9,41 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'java-library'
+    id 'net.thebugmc.gradle.sonatype-central-portal-publisher' version '1.2.4'
+    id 'signing'
 }
 
+description = 'JDBC driver for the Wherobots Cloud Spatial SQL API'
+group = 'com.wherobots.jdbc'
 version = '0.1.0'
 
 repositories {
-    // Use Maven Central for resolving dependencies.
     mavenCentral()
+}
+
+centralPortal {
+    username = System.getenv('OSSRH_USERNAME')
+    password = System.getenv('OSSRH_PASSWORD')
+
+    pom {
+        url = 'https://www.wherobots.com'
+        licenses {
+            license {
+                name = 'The Apache License, Version 2.0'
+                url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+          }
+        }
+        developers {
+            developer {
+                name = 'Wherobots Inc.'
+                email = 'info@wherobots.com'
+            }
+        }
+        scm {
+            connection = 'scm:git:https://github.com/wherobots/wherobots-jdbc-driver'
+            url = 'https://github.com/wherobots/wherobots-jdbc-driver'
+        }
+    }
 }
 
 dependencies {
@@ -42,12 +70,16 @@ java {
 }
 
 tasks.named('jar') {
+    archiveBaseName.set('wherobots-jdbc-driver')
     manifest {
-        attributes('Implementation-Title': project.name,
+        attributes('Implementation-Title': rootProject.name,
                    'Implementation-Version': project.version)
     }
 }
 
 tasks.withType(Jar) {
-    archiveBaseName.set('wherobots-jdbc')
+}
+
+signing {
+    useGpgCmd()
 }


### PR DESCRIPTION
Version 0.1.0 has been successfully published: https://central.sonatype.com/artifact/com.wherobots.jdbc/wherobots-jdbc-driver/overview