### PR TITLE
fix: guard expensive logging operations to avoid unnecessary allocations

### DIFF
--- a/lib/src/main/java/com/wherobots/db/jdbc/WherobotsJdbcConnection.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/WherobotsJdbcConnection.java
@@ -79,7 +79,9 @@ public class WherobotsJdbcConnection implements Connection {
     }
 
     private void handle(Event event) throws Exception {
-        logger.info("Handling event: {}", JsonUtil.serialize(event));
+        if (logger.isDebugEnabled()) {
+            logger.debug("Handling event: {}", JsonUtil.serialize(event));
+        }
         if (event.kind == null || event.executionId == null) {
             // Invalid event.
             return;

--- a/lib/src/main/java/com/wherobots/db/jdbc/WherobotsResultSetMetaData.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/WherobotsResultSetMetaData.java
@@ -20,7 +20,9 @@ public class WherobotsResultSetMetaData implements ResultSetMetaData {
     public WherobotsResultSetMetaData(Schema schema) {
         this.schema = schema;
         this.fields = schema.getFields().stream().map(Field::getName).toArray(String[]::new);
-        logger.info("ResultSet({})", Arrays.asList(fields));
+        if (logger.isDebugEnabled()) {
+            logger.debug("ResultSet({})", Arrays.asList(fields));
+        }
     }
 
     public int getColumnIndex(String name) throws SQLException {

--- a/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSession.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSession.java
@@ -55,13 +55,13 @@ public class WherobotsSession extends WebSocketClient implements Iterable<Frame>
 
     @Override
     public void onMessage(String s) {
-        logger.info("< {}", s);
+        logger.debug("< {}", s);
         this.forward(new Frame(s, null, null));
     }
 
     @Override
     public void onMessage(ByteBuffer bytes) {
-        logger.info("< {}", bytes);
+        logger.debug("< {} bytes", bytes.remaining());
         this.forward(new Frame(null, bytes, null));
     }
 
@@ -78,7 +78,7 @@ public class WherobotsSession extends WebSocketClient implements Iterable<Frame>
 
     @Override
     public void send(String text) {
-        logger.info("> {}", text);
+        logger.debug("> {}", text);
         super.send(text);
     }
 


### PR DESCRIPTION
## Summary

- Guard `JsonUtil.serialize()` in `handle()` with `isDebugEnabled()` check to avoid JSON serialization on every event
- Change WebSocket message logging from INFO to DEBUG level
- Log only `ByteBuffer` size instead of full content to avoid dumping large binary result data
- Guard `Arrays.asList()` in `ResultSetMetaData` constructor with `isDebugEnabled()` check