### PR TITLE
feat: add support for storing query results to cloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,49 @@ The `region` property accepts the following values:
    `jdbc:wherobots://api.cloud.wherobots.com`
 6. Add your `apiKey` in the connection properties
 
+## Storing Results to Cloud Storage
+
+The driver supports storing query results directly to cloud storage and
+returning a presigned URL for download. This is useful for large result sets
+that you want to process outside of JDBC.
+
+This feature is exposed as a Wherobots-specific extension, accessible via
+`unwrap()`:
+
+```java
+import com.wherobots.db.StorageFormat;
+import com.wherobots.db.jdbc.WherobotsStatement;
+import com.wherobots.db.jdbc.models.Store;
+import com.wherobots.db.jdbc.models.StoreResult;
+
+try (Statement stmt = conn.createStatement()) {
+    // Unwrap to access Wherobots-specific features
+    WherobotsStatement wstmt = stmt.unwrap(WherobotsStatement.class);
+
+    // Configure to store results and get a presigned URL
+    wstmt.setStore(Store.forDownload());
+
+    // Execute the query
+    wstmt.execute("SELECT * FROM my_table");
+
+    // Get the presigned URL and file size
+    StoreResult result = wstmt.getStoreResult();
+    System.out.println("Download URL: " + result.resultUri());
+    System.out.println("File size: " + result.size() + " bytes");
+}
+```
+
+### Store Options
+
+The `Store` class provides factory methods for creating store configurations:
+
+| Factory Method | Description |
+|----------------|-------------|
+| `Store.forDownload()` | Single parquet file with presigned URL (most common) |
+| `Store.forDownload(format)` | Single file with presigned URL in specified format |
+
+The `StorageFormat` enum supports: `parquet`, `csv`, and `geojson`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and release

--- a/lib/src/main/java/com/wherobots/db/StorageFormat.java
+++ b/lib/src/main/java/com/wherobots/db/StorageFormat.java
@@ -1,0 +1,14 @@
+package com.wherobots.db;
+
+/**
+ * Storage formats for storing query results to cloud storage.
+ * <p>
+ * Note that those names are purposefully lowercase to match the SQL Session server's expectations.
+ *
+ * @author mpetazzoni
+ */
+public enum StorageFormat {
+    parquet,
+    csv,
+    geojson,
+}

--- a/lib/src/main/java/com/wherobots/db/jdbc/internal/ExecutionResult.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/internal/ExecutionResult.java
@@ -1,5 +1,6 @@
 package com.wherobots.db.jdbc.internal;
 
+import com.wherobots.db.jdbc.models.StoreResult;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 
-public record ExecutionResult(ArrowStreamReader result, Exception error) {}
+public record ExecutionResult(ArrowStreamReader result, Exception error, StoreResult storeResult) {}

--- a/lib/src/main/java/com/wherobots/db/jdbc/models/Event.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/models/Event.java
@@ -27,7 +27,11 @@ public class Event {
     public String executionId;
     public QueryState state;
 
-    public static class StateUpdatedEvent extends Event {}
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class StateUpdatedEvent extends Event {
+        public String resultUri;
+        public Long size;
+    }
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class ErrorEvent extends Event {

--- a/lib/src/main/java/com/wherobots/db/jdbc/models/ExecuteSqlRequest.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/models/ExecuteSqlRequest.java
@@ -1,10 +1,8 @@
 package com.wherobots.db.jdbc.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.wherobots.db.jdbc.WherobotsJdbcConnection;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -13,9 +11,15 @@ public class ExecuteSqlRequest {
     public final String kind = "execute_sql";
     public String executionId;
     public String statement;
+    public Store store;
 
     public ExecuteSqlRequest(String executionId, String statement) {
+        this(executionId, statement, null);
+    }
+
+    public ExecuteSqlRequest(String executionId, String statement, Store store) {
         this.executionId = executionId;
         this.statement = statement;
+        this.store = store;
     }
 }

--- a/lib/src/main/java/com/wherobots/db/jdbc/models/Store.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/models/Store.java
@@ -1,0 +1,84 @@
+package com.wherobots.db.jdbc.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.wherobots.db.StorageFormat;
+
+/**
+ * Configuration for storing query results to cloud storage.
+ * <p>
+ * Examples:
+ * <pre>{@code
+ * // Store as a single file with a presigned URL for download (default parquet format)
+ * Store.forDownload()
+ *
+ * // Store as a single CSV file with a presigned URL for download
+ * Store.forDownload(StorageFormat.csv)
+ * }</pre>
+ *
+ * @author mpetazzoni
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Store {
+
+    private final StorageFormat format;
+    private final boolean single;
+    private final boolean generatePresignedUrl;
+
+    /**
+     * Create a store configuration for downloading results via a presigned URL.
+     * <p>
+     * This is a convenience method that creates a configuration with single file mode
+     * and presigned URL generation enabled, using the default format.
+     *
+     * @return a Store configured for download
+     */
+    public static Store forDownload() {
+        return new Store(null, true, true);
+    }
+
+    /**
+     * Create a store configuration for downloading results via a presigned URL.
+     * <p>
+     * This is a convenience method that creates a configuration with single file mode
+     * and presigned URL generation enabled.
+     *
+     * @param format the storage format (parquet, csv, or geojson)
+     * @return a Store configured for download
+     */
+    public static Store forDownload(StorageFormat format) {
+        return new Store(format, true, true);
+    }
+
+    /**
+     * Create a store configuration with all options.
+     *
+     * @param format the storage format (parquet, csv, or geojson)
+     * @param single true to store as a single file, false for multiple files
+     * @param generatePresignedUrl true to generate a presigned URL for the result
+     * @throws IllegalArgumentException if generatePresignedUrl is true but single is false
+     */
+    private Store(StorageFormat format, boolean single, boolean generatePresignedUrl) {
+        if (generatePresignedUrl && !single) {
+            throw new IllegalArgumentException(
+                    "Cannot generate a presigned URL without single file mode enabled");
+        }
+        this.format = format;
+        this.single = single;
+        this.generatePresignedUrl = generatePresignedUrl;
+    }
+
+    public StorageFormat getFormat() {
+        return format;
+    }
+
+    public boolean isSingle() {
+        return single;
+    }
+
+    public boolean isGeneratePresignedUrl() {
+        return generatePresignedUrl;
+    }
+}

--- a/lib/src/main/java/com/wherobots/db/jdbc/models/StoreResult.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/models/StoreResult.java
@@ -1,0 +1,11 @@
+package com.wherobots.db.jdbc.models;
+
+/**
+ * Result information for a query that was stored to cloud storage.
+ *
+ * @param resultUri the URI or presigned URL of the stored result
+ * @param size the size of the stored result in bytes, or null if not available
+ * @author mpetazzoni
+ */
+public record StoreResult(String resultUri, Long size) {
+}

--- a/lib/src/main/java/com/wherobots/db/jdbc/serde/JsonUtil.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/serde/JsonUtil.java
@@ -1,5 +1,6 @@
 package com.wherobots.db.jdbc.serde;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,6 +13,11 @@ public class JsonUtil {
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static {
+            // SQL Session requires all values to be strings, and they get coerced back into the appropriate type.
+            MAPPER.configOverride(boolean.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
+    }
 
     public static String serialize(Object o) throws IllegalArgumentException {
         try {


### PR DESCRIPTION
## Summary

Add support for the SQL Session `store` parameter, allowing query results to be stored in cloud storage with a presigned URL returned for download.

Usage:
```java
WherobotsStatement wstmt = stmt.unwrap(WherobotsStatement.class);
wstmt.setStore(Store.forDownload());
wstmt.execute("SELECT * FROM my_table");
StoreResult result = wstmt.getStoreResult();
// result.resultUri() -> presigned S3 URL
// result.size() -> file size in bytes
```

When store mode is configured, the driver skips the normal result retrieval flow and immediately returns with the stored result URI once the query succeeds.