### PR TITLE
feat: add options support to Store for format-specific storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,22 @@ The `Store` class provides factory methods for creating store configurations:
 |----------------|-------------|
 | `Store.forDownload()` | Single parquet file with presigned URL (most common) |
 | `Store.forDownload(format)` | Single file with presigned URL in specified format |
+| `Store.forDownload(format, options)` | Single file with presigned URL, format, and additional options |
 
 The `StorageFormat` enum supports: `parquet`, `csv`, and `geojson`.
+
+You can pass format-specific storage options as a `Map<String, String>`.
+These correspond to the options available in Spark's `OPTIONS (...)` clause:
+
+```java
+import java.util.Map;
+
+// GeoJSON with null field handling
+wstmt.setStore(Store.forDownload(StorageFormat.geojson, Map.of("ignoreNullFields", "false")));
+
+// CSV with header and custom delimiter
+wstmt.setStore(Store.forDownload(StorageFormat.csv, Map.of("header", "true", "delimiter", ",")));
+```
 
 ## Contributing
 

--- a/lib/src/main/java/com/wherobots/db/jdbc/models/Store.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/models/Store.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.wherobots.db.StorageFormat;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Configuration for storing query results to cloud storage.
  * <p>
@@ -15,6 +19,12 @@ import com.wherobots.db.StorageFormat;
  *
  * // Store as a single CSV file with a presigned URL for download
  * Store.forDownload(StorageFormat.csv)
+ *
+ * // Store as GeoJSON with additional storage options
+ * Store.forDownload(StorageFormat.geojson, Map.of("ignoreNullFields", "false"))
+ *
+ * // Store as CSV with header option
+ * Store.forDownload(StorageFormat.csv, Map.of("header", "true"))
  * }</pre>
  *
  * @author mpetazzoni
@@ -26,6 +36,7 @@ public class Store {
     private final StorageFormat format;
     private final boolean single;
     private final boolean generatePresignedUrl;
+    private final Map<String, String> options;
 
     /**
      * Create a store configuration for downloading results via a presigned URL.
@@ -36,7 +47,7 @@ public class Store {
      * @return a Store configured for download
      */
     public static Store forDownload() {
-        return new Store(null, true, true);
+        return new Store(null, true, true, null);
     }
 
     /**
@@ -49,18 +60,43 @@ public class Store {
      * @return a Store configured for download
      */
     public static Store forDownload(StorageFormat format) {
-        return new Store(format, true, true);
+        return new Store(format, true, true, null);
     }
 
     /**
-     * Create a store configuration with all options.
+     * Create a store configuration for downloading results via a presigned URL,
+     * with additional storage options.
+     * <p>
+     * This is a convenience method that creates a configuration with single file mode
+     * and presigned URL generation enabled, with format-specific options. These options
+     * correspond to the options available in Spark's {@code OPTIONS (...)} clause when
+     * writing data.
+     * <p>
+     * Examples of options by format:
+     * <ul>
+     *   <li>GeoJSON: {@code ignoreNullFields} ({@code "true"}/{@code "false"})</li>
+     *   <li>CSV: {@code header} ({@code "true"}/{@code "false"}), {@code delimiter}, {@code quote}</li>
+     *   <li>Parquet: {@code compression} ({@code "snappy"}, {@code "gzip"}, etc.)</li>
+     * </ul>
+     *
+     * @param format the storage format (parquet, csv, or geojson)
+     * @param options additional format-specific storage options
+     * @return a Store configured for download with options
+     */
+    public static Store forDownload(StorageFormat format, Map<String, String> options) {
+        return new Store(format, true, true, options);
+    }
+
+    /**
+     * Create a store configuration with all parameters.
      *
      * @param format the storage format (parquet, csv, or geojson)
      * @param single true to store as a single file, false for multiple files
      * @param generatePresignedUrl true to generate a presigned URL for the result
+     * @param options additional format-specific storage options, or null for no options
      * @throws IllegalArgumentException if generatePresignedUrl is true but single is false
      */
-    private Store(StorageFormat format, boolean single, boolean generatePresignedUrl) {
+    private Store(StorageFormat format, boolean single, boolean generatePresignedUrl, Map<String, String> options) {
         if (generatePresignedUrl && !single) {
             throw new IllegalArgumentException(
                     "Cannot generate a presigned URL without single file mode enabled");
@@ -68,6 +104,9 @@ public class Store {
         this.format = format;
         this.single = single;
         this.generatePresignedUrl = generatePresignedUrl;
+        this.options = options != null && !options.isEmpty()
+                ? Collections.unmodifiableMap(new LinkedHashMap<>(options))
+                : null;
     }
 
     public StorageFormat getFormat() {
@@ -80,5 +119,14 @@ public class Store {
 
     public boolean isGeneratePresignedUrl() {
         return generatePresignedUrl;
+    }
+
+    /**
+     * Get the additional format-specific storage options.
+     *
+     * @return an unmodifiable map of options, or null if no options were specified
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 }

--- a/lib/src/test/java/com/wherobots/db/jdbc/models/StoreTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/models/StoreTest.java
@@ -1,0 +1,114 @@
+package com.wherobots.db.jdbc.models;
+
+import com.wherobots.db.StorageFormat;
+import com.wherobots.db.jdbc.serde.JsonUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StoreTest {
+
+    @Test
+    void forDownloadDefaultFormat() {
+        Store store = Store.forDownload();
+        assertNull(store.getFormat());
+        assertTrue(store.isSingle());
+        assertTrue(store.isGeneratePresignedUrl());
+        assertNull(store.getOptions());
+
+        String json = JsonUtil.serialize(store);
+        assertFalse(json.contains("\"options\""), "options should be omitted when null");
+        assertFalse(json.contains("\"format\""), "format should be omitted when null");
+    }
+
+    @Test
+    void forDownloadWithFormat() {
+        Store store = Store.forDownload(StorageFormat.csv);
+        assertEquals(StorageFormat.csv, store.getFormat());
+        assertTrue(store.isSingle());
+        assertTrue(store.isGeneratePresignedUrl());
+        assertNull(store.getOptions());
+
+        String json = JsonUtil.serialize(store);
+        assertTrue(json.contains("\"format\":\"csv\""));
+        assertFalse(json.contains("\"options\""), "options should be omitted when null");
+    }
+
+    @Test
+    void forDownloadWithFormatAndOptions() {
+        Map<String, String> options = Map.of("ignoreNullFields", "false");
+        Store store = Store.forDownload(StorageFormat.geojson, options);
+        assertEquals(StorageFormat.geojson, store.getFormat());
+        assertTrue(store.isSingle());
+        assertTrue(store.isGeneratePresignedUrl());
+        assertEquals(Map.of("ignoreNullFields", "false"), store.getOptions());
+
+        String json = JsonUtil.serialize(store);
+        assertTrue(json.contains("\"format\":\"geojson\""));
+        assertTrue(json.contains("\"options\""));
+        assertTrue(json.contains("\"ignoreNullFields\":\"false\""));
+    }
+
+    @Test
+    void forDownloadWithMultipleOptions() {
+        Map<String, String> options = Map.of(
+                "header", "true",
+                "delimiter", ","
+        );
+        Store store = Store.forDownload(StorageFormat.csv, options);
+
+        String json = JsonUtil.serialize(store);
+        assertTrue(json.contains("\"header\":\"true\""));
+        assertTrue(json.contains("\"delimiter\":\",\""));
+    }
+
+    @Test
+    void forDownloadWithEmptyOptions() {
+        Store store = Store.forDownload(StorageFormat.csv, Map.of());
+        assertNull(store.getOptions(), "empty options should be stored as null");
+
+        String json = JsonUtil.serialize(store);
+        assertFalse(json.contains("\"options\""), "empty options should be omitted from JSON");
+    }
+
+    @Test
+    void forDownloadWithNullOptions() {
+        Store store = Store.forDownload(StorageFormat.csv, null);
+        assertNull(store.getOptions());
+
+        String json = JsonUtil.serialize(store);
+        assertFalse(json.contains("\"options\""), "null options should be omitted from JSON");
+    }
+
+    @Test
+    void optionsAreImmutable() {
+        Map<String, String> options = new java.util.HashMap<>();
+        options.put("key", "value");
+        Store store = Store.forDownload(StorageFormat.csv, options);
+
+        // Modifying the original map should not affect the store
+        options.put("extra", "value2");
+        assertEquals(1, store.getOptions().size());
+
+        // The returned map should be unmodifiable
+        assertThrows(UnsupportedOperationException.class, () -> {
+            store.getOptions().put("extra", "value2");
+        });
+    }
+
+    @Test
+    void executeSqlRequestWithStoreOptions() {
+        Map<String, String> options = Map.of("ignoreNullFields", "false");
+        Store store = Store.forDownload(StorageFormat.geojson, options);
+        ExecuteSqlRequest request = new ExecuteSqlRequest("exec-123", "SELECT 1", store);
+
+        String json = JsonUtil.serialize(request);
+        assertTrue(json.contains("\"execution_id\":\"exec-123\""));
+        assertTrue(json.contains("\"statement\":\"SELECT 1\""));
+        assertTrue(json.contains("\"store\""));
+        assertTrue(json.contains("\"options\""));
+        assertTrue(json.contains("\"ignoreNullFields\":\"false\""));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `Store.forDownload(StorageFormat format, Map<String, String> options)` factory method, allowing users to pass format-specific storage options (e.g. `ignoreNullFields`, `header`, `delimiter`) that correspond to Spark's `OPTIONS (...)` clause
- The `options` map is serialized as a nested JSON object in the `store` field of the `execute_sql` request
- Existing `forDownload()` and `forDownload(format)` methods are fully backward compatible — no changes required for current users

## Motivation

Users storing results via `wstmt.setStore(Store.forDownload())` had no way to pass configurations like:
```sql
CREATE TABLE output_table
USING geojson
OPTIONS (ignoreNullFields 'false')
```

Now they can:
```java
wstmt.setStore(Store.forDownload(StorageFormat.geojson, Map.of("ignoreNullFields", "false")));
```

## Changes

- **`Store.java`** — Added `Map<String, String> options` field, new `forDownload(format, options)` factory method, and `getOptions()` getter. Options are defensively copied and stored as an unmodifiable map; empty/null options are normalized to `null` and omitted from JSON serialization.
- **`StoreTest.java`** (new) — 8 tests covering serialization, backward compatibility, empty/null handling, immutability, and end-to-end `ExecuteSqlRequest` serialization.
- **`README.md`** — Updated Store Options section with the new factory method and usage examples.