### PR TITLE
feat: add AWS US East 2 (Ohio) region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The `region` property accepts the following values:
 |--------|----------|
 | `AWS_US_WEST_2` | US West (Oregon) - default |
 | `AWS_US_EAST_1` | US East (N. Virginia) |
+| `AWS_US_EAST_2` | US East (Ohio) |
 | `AWS_EU_WEST_1` | EU (Ireland) |
 | `AWS_AP_SOUTH_1` | Asia Pacific (Mumbai) |
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 description = 'JDBC driver for the Wherobots Cloud Spatial SQL API'
 group = 'com.wherobots.jdbc'
-version = '0.3.0'
+version = '0.4.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/wherobots/db/Region.java
+++ b/lib/src/main/java/com/wherobots/db/Region.java
@@ -4,6 +4,7 @@ public enum Region {
     // Americas
     AWS_US_WEST_2("aws-us-west-2"),
     AWS_US_EAST_1("aws-us-east-1"),
+    AWS_US_EAST_2("aws-us-east-2"),
 
     // EMEA
     AWS_EU_WEST_1("aws-eu-west-1"),


### PR DESCRIPTION
## Summary

Add `AWS_US_EAST_2` (`aws-us-east-2`, Ohio) as a supported compute region and bump version to 0.4.0.

## Release

Merging this PR will automatically publish to Maven Central via the release workflow (triggered by `build.gradle` version change on `main`).