### PR TITLE
feat: accept arbitrary region/runtime strings, make them optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Configure the driver using properties passed to `DriverManager.getConnection()`:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `runtime` | `Runtime` | `TINY` | The runtime size to use (see [Runtimes](#runtimes)) |
-| `region` | `Region` | `AWS_US_WEST_2` | The cloud region to run in (see [Regions](#regions)) |
+| `runtime` | `String` | _(org default)_ | The runtime size to use. Accepts an enum name (see [Runtimes](#runtimes)) or any API value; omit to use your organization's default |
+| `region` | `String` | _(org default)_ | The cloud region to run in. Accepts an enum name (see [Regions](#regions)), an API value, or a BYOC region string (e.g. `byoc-acme-us-east-1`); omit to use your organization's default |
 | `version` | `String` | _(latest)_ | Pin to a specific WherobotsDB runtime version |
 | `sessionType` | `SessionType` | `MULTI` | `SINGLE` or `MULTI` concurrent connections |
 | `forceNew` | `boolean` | `false` | Force creation of a new session instead of reusing an existing one |
@@ -98,7 +98,9 @@ Configure the driver using properties passed to `DriverManager.getConnection()`:
 <details>
 <summary><h3>Runtimes</h3></summary>
 
-The `runtime` property accepts the following values:
+The `runtime` property accepts the enum names below (or their equivalent API
+value, e.g. `small`). Omit the property to use your organization's configured
+default runtime.
 
 | Runtime | Description |
 |---------|-------------|
@@ -124,7 +126,10 @@ The `runtime` property accepts the following values:
 <details>
 <summary><h3>Regions</h3></summary>
 
-The `region` property accepts the following values:
+The `region` property accepts the enum names below (for backward compatibility),
+the equivalent API value (e.g. `aws-us-west-2`), or any other region string such
+as a BYOC region (e.g. `byoc-acme-us-east-1`) — unknown values are passed to the
+API as-is. Omit the property to use your organization's configured default.
 
 | Region | Location |
 |--------|----------|

--- a/lib/src/main/java/com/wherobots/db/Region.java
+++ b/lib/src/main/java/com/wherobots/db/Region.java
@@ -17,4 +17,26 @@ public enum Region {
     Region(String name) {
         this.name = name;
     }
+
+    /**
+     * Resolves a user-supplied region property to the value sent to the API.
+     *
+     * <p>Accepts either an enum constant name (e.g. {@code AWS_US_WEST_2}), for
+     * backward compatibility, which is mapped to its API value
+     * ({@code aws-us-west-2}); or a raw string — an API value such as
+     * {@code aws-us-west-2} or a BYOC region such as {@code byoc-acme-us-east-1}
+     * — which is returned unchanged. {@code null} is returned as {@code null} so
+     * the caller can omit the region and let the API apply the organization's
+     * configured default.
+     */
+    public static String toApiValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Region.valueOf(value).name;
+        } catch (IllegalArgumentException e) {
+            return value;
+        }
+    }
 }

--- a/lib/src/main/java/com/wherobots/db/Runtime.java
+++ b/lib/src/main/java/com/wherobots/db/Runtime.java
@@ -42,4 +42,24 @@ public enum Runtime {
     Runtime(String name) {
         this.name = name;
     }
+
+    /**
+     * Resolves a user-supplied runtime property to the value sent to the API.
+     *
+     * <p>Accepts either an enum constant name (e.g. {@code SMALL}), for backward
+     * compatibility, which is mapped to its API value ({@code small}); or a raw
+     * string — an API value such as {@code small} — which is returned unchanged.
+     * {@code null} is returned as {@code null} so the caller can omit the
+     * runtime and let the API apply the organization's configured default.
+     */
+    public static String toApiValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Runtime.valueOf(value).name;
+        } catch (IllegalArgumentException e) {
+            return value;
+        }
+    }
 }

--- a/lib/src/main/java/com/wherobots/db/jdbc/WherobotsJdbcDriver.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/WherobotsJdbcDriver.java
@@ -30,7 +30,24 @@ public class WherobotsJdbcDriver implements Driver {
 
     public static final String API_KEY_PROP = "apiKey";
     public static final String TOKEN_PROP = "token";
+
+    /**
+     * The compute runtime to use. Accepts a {@link com.wherobots.db.Runtime}
+     * enum name or a raw string; the value is passed to the API as-is. Override
+     * the default runtime set for your organization — only set this if you need
+     * a specific runtime instead of the one your administrator has configured.
+     * When omitted, your organization's default runtime is used.
+     */
     public static final String RUNTIME_PROP = "runtime";
+
+    /**
+     * The compute region to run in. Accepts a {@link com.wherobots.db.Region}
+     * enum name or a raw string (e.g. a BYOC region such as
+     * {@code byoc-acme-us-east-1}); the value is passed to the API as-is.
+     * Override the default region set for your organization — only set this if
+     * you intend to use a specific region instead of the one your administrator
+     * has configured. When omitted, your organization's default region is used.
+     */
     public static final String REGION_PROP = "region";
     public static final String VERSION_PROP = "version";
     public static final String SESSION_TYPE_PROP = "sessionType";
@@ -50,8 +67,6 @@ public class WherobotsJdbcDriver implements Driver {
     public static final String DEFAULT_ENDPOINT = "api.cloud.wherobots.com";
     public static final String STAGING_ENDPOINT = "api.staging.wherobots.com";
 
-    public static final Runtime DEFAULT_RUNTIME = Runtime.TINY;
-    public static final Region DEFAULT_REGION = Region.AWS_US_WEST_2;
     public static final SessionType DEFAULT_SESSION_TYPE = SessionType.MULTI;
     public static final boolean DEFAULT_FORCE_NEW = false;
 
@@ -79,17 +94,14 @@ public class WherobotsJdbcDriver implements Driver {
             throw new SQLException("Invalid URL: " + url, e);
         }
 
-        Runtime runtime = DEFAULT_RUNTIME;
-        String runtimeName = info.getProperty(RUNTIME_PROP);
-        if (StringUtils.isNotBlank(runtimeName)) {
-            runtime = Runtime.valueOf(runtimeName);
-        }
-
-        Region region = DEFAULT_REGION;
-        String regionName = info.getProperty(REGION_PROP);
-        if (StringUtils.isNotBlank(regionName)) {
-            region = Region.valueOf(regionName);
-        }
+        // Resolve region/runtime to the value sent to the API: a known enum
+        // constant name (e.g. AWS_US_WEST_2) maps to its API value for backward
+        // compatibility, while any other string (an API value or a BYOC region)
+        // is passed through untouched — so new or BYOC values work without a
+        // driver release. When omitted (null), the API applies the
+        // organization's configured default region/runtime.
+        String runtime = Runtime.toApiValue(StringUtils.trimToNull(info.getProperty(RUNTIME_PROP)));
+        String region = Region.toApiValue(StringUtils.trimToNull(info.getProperty(REGION_PROP)));
 
         String version = null;
         String givenVersion = info.getProperty(VERSION_PROP);

--- a/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -44,7 +46,7 @@ public abstract class WherobotsSessionSupplier {
     static String buildSessionUri(String host, String region, boolean forceNew) {
         StringBuilder uri = new StringBuilder(String.format(SQL_SESSION_ENDPOINT, host, forceNew));
         if (region != null && !region.isBlank()) {
-            uri.append("&region=").append(region);
+            uri.append("&region=").append(URLEncoder.encode(region, StandardCharsets.UTF_8));
         }
         return uri.toString();
     }

--- a/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
@@ -3,8 +3,6 @@ package com.wherobots.db.jdbc.session;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.wherobots.db.AppStatus;
-import com.wherobots.db.Region;
-import com.wherobots.db.Runtime;
 import com.wherobots.db.SessionType;
 import com.wherobots.db.jdbc.serde.JsonUtil;
 import io.github.resilience4j.core.IntervalFunction;
@@ -35,8 +33,21 @@ public abstract class WherobotsSessionSupplier {
 
     private static final Logger logger = LoggerFactory.getLogger(WherobotsSessionSupplier.class);
 
-    private static final String SQL_SESSION_ENDPOINT = "https://%s/sql/session?region=%s&force_new=%s";
+    private static final String SQL_SESSION_ENDPOINT = "https://%s/sql/session?force_new=%s";
     private static final String PROTOCOL_VERSION = "1.0.0";
+
+    /**
+     * Builds the SQL session creation URL, appending {@code region} only when
+     * one was provided. An omitted region lets the API apply the
+     * organization's configured default region.
+     */
+    static String buildSessionUri(String host, String region, boolean forceNew) {
+        StringBuilder uri = new StringBuilder(String.format(SQL_SESSION_ENDPOINT, host, forceNew));
+        if (region != null && !region.isBlank()) {
+            uri.append("&region=").append(region);
+        }
+        return uri.toString();
+    }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private record SqlSessionRequestPayload(
@@ -60,7 +71,7 @@ public abstract class WherobotsSessionSupplier {
      * @return
      * @throws SQLException
      */
-    public static WherobotsSession create(String host, Runtime runtime, Region region,
+    public static WherobotsSession create(String host, String runtime, String region,
                                           String version, SessionType sessionType,
                                           boolean forceNew, Integer shutdownAfterInactiveSeconds,
                                           Map<String, String> headers)
@@ -112,8 +123,8 @@ public abstract class WherobotsSessionSupplier {
     private record SqlSessionSupplier(HttpClient client,
                                       Map<String, String> headers,
                                       String host,
-                                      Runtime runtime,
-                                      Region region,
+                                      String runtime,
+                                      String region,
                                       String version,
                                       SessionType sessionType,
                                       boolean forceNew,
@@ -124,22 +135,22 @@ public abstract class WherobotsSessionSupplier {
         public URI get() throws IOException, InterruptedException {
             logger.info("Requesting {}{} runtime using {} session {}in {} from {}...",
                     forceNew ? "new " : "",
-                    runtime.name,
+                    runtime != null ? runtime : "org-default",
                     sessionType.name,
                     version != null ? String.format("running %s ", version) : "",
-                    region.name,
+                    region != null ? region : "org-default",
                     host);
 
             HttpRequest.BodyPublisher body = HttpRequest.BodyPublishers.ofString(
                     JsonUtil.serialize(new SqlSessionRequestPayload(
-                        runtime.name,
+                        runtime,
                         shutdownAfterInactiveSeconds,
                         version,
                         sessionType.name)));
 
             HttpRequest.Builder request = HttpRequest.newBuilder()
                     .POST(body)
-                    .uri(URI.create(String.format(SQL_SESSION_ENDPOINT, host, region.name, forceNew)))
+                    .uri(URI.create(buildSessionUri(host, region, forceNew)))
                     .header("Content-Type", "application/json");
             headers.forEach(request::header);
 

--- a/lib/src/test/java/com/wherobots/db/RegionTest.java
+++ b/lib/src/test/java/com/wherobots/db/RegionTest.java
@@ -1,0 +1,30 @@
+package com.wherobots.db;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RegionTest {
+
+    @Test
+    void toApiValueMapsLegacyEnumName() {
+        // Backward compatibility: the enum constant name maps to its API value.
+        assertEquals("aws-us-west-2", Region.toApiValue("AWS_US_WEST_2"));
+    }
+
+    @Test
+    void toApiValuePassesThroughApiValue() {
+        assertEquals("aws-us-west-2", Region.toApiValue("aws-us-west-2"));
+    }
+
+    @Test
+    void toApiValuePassesThroughByocRegion() {
+        assertEquals("byoc-acme-us-east-1", Region.toApiValue("byoc-acme-us-east-1"));
+    }
+
+    @Test
+    void toApiValueReturnsNullForNull() {
+        assertNull(Region.toApiValue(null));
+    }
+}

--- a/lib/src/test/java/com/wherobots/db/RuntimeTest.java
+++ b/lib/src/test/java/com/wherobots/db/RuntimeTest.java
@@ -1,0 +1,25 @@
+package com.wherobots.db;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RuntimeTest {
+
+    @Test
+    void toApiValueMapsLegacyEnumName() {
+        // Backward compatibility: the enum constant name maps to its API value.
+        assertEquals("small", Runtime.toApiValue("SMALL"));
+    }
+
+    @Test
+    void toApiValuePassesThroughApiValue() {
+        assertEquals("x-large", Runtime.toApiValue("x-large"));
+    }
+
+    @Test
+    void toApiValueReturnsNullForNull() {
+        assertNull(Runtime.toApiValue(null));
+    }
+}

--- a/lib/src/test/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplierTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplierTest.java
@@ -28,4 +28,14 @@ class WherobotsSessionSupplierTest {
                 "api.example.com", "byoc-acme-us-east-1", false);
         assertTrue(uri.contains("region=byoc-acme-us-east-1"));
     }
+
+    @Test
+    void buildSessionUriEncodesRegionReservedCharacters() {
+        String uri = WherobotsSessionSupplier.buildSessionUri(
+                "api.example.com", "evil&force_new=true", false);
+        // The reserved characters must be percent-encoded so they cannot
+        // inject additional query parameters or corrupt the query string.
+        assertTrue(uri.contains("region=evil%26force_new%3Dtrue"));
+        assertFalse(uri.contains("region=evil&force_new=true"));
+    }
 }

--- a/lib/src/test/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplierTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplierTest.java
@@ -1,0 +1,31 @@
+package com.wherobots.db.jdbc.session;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WherobotsSessionSupplierTest {
+
+    @Test
+    void buildSessionUriOmitsRegionWhenNull() {
+        String uri = WherobotsSessionSupplier.buildSessionUri("api.example.com", null, false);
+        assertEquals("https://api.example.com/sql/session?force_new=false", uri);
+        assertFalse(uri.contains("region="));
+    }
+
+    @Test
+    void buildSessionUriOmitsRegionWhenBlank() {
+        String uri = WherobotsSessionSupplier.buildSessionUri("api.example.com", "   ", true);
+        assertFalse(uri.contains("region="));
+        assertTrue(uri.contains("force_new=true"));
+    }
+
+    @Test
+    void buildSessionUriIncludesRegionWhenSet() {
+        String uri = WherobotsSessionSupplier.buildSessionUri(
+                "api.example.com", "byoc-acme-us-east-1", false);
+        assertTrue(uri.contains("region=byoc-acme-us-east-1"));
+    }
+}


### PR DESCRIPTION
## Summary

The `region` / `runtime` JDBC properties are no longer enum-validated and no longer get a hardcoded client-side default.

- `Region` / `Runtime` gain `toApiValue(String)`: a known enum constant name (e.g. `AWS_US_WEST_2`) maps to its API value (`aws-us-west-2`) for **backward compatibility**, while any other string — an API value (`aws-us-west-2`) or a BYOC region (`byoc-acme-us-east-1`) — is passed through untouched. New/BYOC values work without a driver release.
- `WherobotsJdbcDriver` resolves the properties via `toApiValue`; `WherobotsSessionSupplier` now takes `String` region/runtime and **omits them from the request when null**, so the API applies the organization's configured default. Removed the now-unused `DEFAULT_RUNTIME` / `DEFAULT_REGION` constants.
- Extracted `WherobotsSessionSupplier.buildSessionUri` which drops `region=` from the URL when unset.
- Added doc comments (override-vs-org-default) on the `RUNTIME_PROP` / `REGION_PROP` constants and updated the README.

**Backward compatibility:** existing configs using uppercase enum names (`region=AWS_US_WEST_2`, `runtime=SMALL`) keep working — they're translated to the API value as before.

**Why:** part of the BYOC region rollout. Depends on wherobots/studio-backend#2208 (region/runtime optional on `POST /sql/session`).

## Test plan
\`\`\`
./gradlew test  ->  BUILD SUCCESSFUL
\`\`\`
New tests: `RegionTest` / `RuntimeTest` (toApiValue: legacy enum name, API value, BYOC passthrough, null) and `WherobotsSessionSupplierTest` (buildSessionUri omits/includes region).