### PR TITLE
feat: emit the X-Wherobots-Client attribution header (WBC-820)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Configure the driver using properties passed to `DriverManager.getConnection()`:
 | `sessionType` | `SessionType` | `MULTI` | `SINGLE` or `MULTI` concurrent connections |
 | `forceNew` | `boolean` | `false` | Force creation of a new session instead of reusing an existing one |
 | `wsUri` | `String` | _(none)_ | Connect directly to a WebSocket URI (advanced) |
+| `clientChain` | `String` | _(none)_ | Upstream client chain to attribute the connection to (see [Client attribution](#client-attribution)) |
 
 ### Result Options
 
@@ -140,6 +141,34 @@ API as-is. Omit the property to use your organization's configured default.
 | `AWS_AP_SOUTH_1` | Asia Pacific (Mumbai) |
 
 </details>
+
+## Client attribution
+
+Every request the driver makes — session creation, session polling, and the
+session WebSocket upgrade — carries an `X-Wherobots-Client` header identifying
+the driver:
+
+```
+X-Wherobots-Client: client=jdbc;ver=0.4.0;plat=mac-os-x
+```
+
+The header is an ordered, comma-separated list of hops; the leftmost hop is the
+origin client and each component appends its own hop on the right. It is
+advisory telemetry used for attribution and analytics, and never affects
+authentication or authorization.
+
+If you are embedding the driver in another Wherobots client and already have a
+chain to attribute the connection to, pass it as `clientChain` and the driver
+appends its own hop to the right of it:
+
+```java
+props.put("clientChain", "client=claude_web, client=mcp;ver=0.9");
+// X-Wherobots-Client: client=claude_web, client=mcp;ver=0.9, client=jdbc;ver=0.4.0;plat=mac-os-x
+```
+
+The value is sanitized — characters that would corrupt the header grammar are
+replaced — and dropped entirely if it would push the header past its 512-byte
+bound, so a bad `clientChain` can never break a connection.
 
 ## Using with DataGrip
 

--- a/lib/src/main/java/com/wherobots/db/jdbc/ClientHeader.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/ClientHeader.java
@@ -186,10 +186,14 @@ public final class ClientHeader {
         }
         String sanitized = UNSAFE_PARAM_CHARS.matcher(value.trim()).replaceAll("-");
         // Leading/trailing separators carry no information and read as noise.
-        sanitized = sanitized.replaceAll("^-+", "").replaceAll("-+$", "");
-        return sanitized.length() > MAX_PARAM_LENGTH
-                ? sanitized.substring(0, MAX_PARAM_LENGTH)
-                : sanitized;
+        sanitized = sanitized.replaceAll("^-+", "");
+        if (sanitized.length() > MAX_PARAM_LENGTH) {
+            sanitized = sanitized.substring(0, MAX_PARAM_LENGTH);
+        }
+        // Stripped after truncation as well as before it: the cut can land
+        // immediately after a replaced character and expose a trailing `-`
+        // that was in the middle of the value a moment ago.
+        return sanitized.replaceAll("-+$", "");
     }
 
     private static int utf8Length(String value) {

--- a/lib/src/main/java/com/wherobots/db/jdbc/ClientHeader.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/ClientHeader.java
@@ -1,0 +1,198 @@
+package com.wherobots.db.jdbc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Helpers for the shared, cross-client {@code X-Wherobots-Client} attribution
+ * header.
+ * <p>
+ * The header is an ordered, append-only, comma-separated list of hops, where
+ * each hop has the form {@code client=<token>} optionally followed by
+ * {@code ;key=value} parameters ({@code ver}, {@code plat}, {@code cmd}). The
+ * <em>leftmost</em> hop is the origin client and each component appends its own
+ * hop <em>on the right</em>. This driver's hop is
+ * {@code client=jdbc;ver=<driver version>;plat=<os name>}.
+ * </p>
+ * <p>
+ * The driver is normally an origin client and emits a single hop. A caller that
+ * is itself acting on behalf of an upstream Wherobots client (a BI tool
+ * integration, a service embedding the driver) can pass that upstream chain
+ * through the {@code clientChain} connection property; it is sanitized and kept
+ * to the left of this driver's hop.
+ * </p>
+ * <p>
+ * The header is <strong>advisory only</strong>: it is client-asserted, used for
+ * attribution and analytics, and must never influence authentication or
+ * authorization.
+ * </p>
+ */
+public final class ClientHeader {
+
+    /** Canonical name of the shared client-chain header. */
+    public static final String HEADER_NAME = "X-Wherobots-Client";
+
+    /** This driver's stable token in the shared client vocabulary. */
+    public static final String CLIENT_TOKEN = "jdbc";
+
+    /**
+     * Maximum size of the rendered header value, in UTF-8 bytes. A larger value
+     * is treated as malformed by the server-side parser, which then attributes
+     * the request to {@code unknown} — so we never emit one.
+     */
+    public static final int MAX_HEADER_BYTES = 512;
+
+    /** Recorded when the driver version cannot be determined. */
+    static final String UNKNOWN_VERSION = "unknown";
+
+    /**
+     * Individual tokens are kept well under 64 characters, per the header
+     * convention.
+     */
+    private static final int MAX_PARAM_LENGTH = 63;
+
+    /**
+     * Characters allowed in a parameter value we render ourselves. Anything
+     * else — including the {@code ,} and {@code ;} delimiters and any control
+     * character — collapses to a single hyphen.
+     */
+    private static final Pattern UNSAFE_PARAM_CHARS = Pattern.compile("[^A-Za-z0-9._+-]+");
+
+    /**
+     * Characters allowed in a caller-supplied upstream chain. The chain carries
+     * its own {@code ,} / {@code ;} / {@code =} grammar, so those are kept;
+     * everything outside this set (notably CR, LF and other control characters,
+     * which would allow header injection) becomes an underscore.
+     */
+    private static final Pattern UNSAFE_CHAIN_CHARS = Pattern.compile("[^A-Za-z0-9._+:/@=;, -]");
+
+    private static final Pattern REPEATED_WHITESPACE = Pattern.compile("\\s+");
+
+    private ClientHeader() {}
+
+    /**
+     * Returns a copy of {@code headers} carrying a well-formed
+     * {@code X-Wherobots-Client} value.
+     * <p>
+     * Any existing entry for the header — matched case-insensitively, since HTTP
+     * header names are case-insensitive — is treated as the upstream chain and
+     * collapsed into the canonical key, so the request carries exactly one such
+     * header with this driver's hop appended on the right.
+     * </p>
+     *
+     * @param headers the outgoing headers; may be null or immutable, and is
+     *                never modified
+     * @return a new mutable map with the attribution header set
+     */
+    public static Map<String, String> withHop(Map<String, String> headers) {
+        Map<String, String> result = new LinkedHashMap<>();
+        String upstream = null;
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey() != null && entry.getKey().equalsIgnoreCase(HEADER_NAME)) {
+                    upstream = entry.getValue();
+                    continue;
+                }
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        result.put(HEADER_NAME, value(upstream));
+        return result;
+    }
+
+    /**
+     * Renders the full header value: the sanitized upstream chain, if any,
+     * followed by this driver's own hop.
+     *
+     * @param upstreamChain an upstream chain to prepend, or null
+     * @return a header value that always fits within {@link #MAX_HEADER_BYTES}
+     */
+    public static String value(String upstreamChain) {
+        String hop = hop(driverVersion(), System.getProperty("os.name"));
+        String chain = sanitizeChain(upstreamChain);
+        if (chain.isEmpty()) {
+            return hop;
+        }
+
+        String combined = chain + ", " + hop;
+        if (utf8Length(combined) > MAX_HEADER_BYTES) {
+            // Truncating mid-chain would corrupt the grammar, and an oversized
+            // value makes the whole header unparseable — so drop the untrusted
+            // upstream chain and keep our own attributable hop.
+            return hop;
+        }
+        return combined;
+    }
+
+    /**
+     * Renders this driver's single hop, {@code client=jdbc;ver=<version>} plus
+     * {@code ;plat=<platform>} when the platform is known. An unavailable
+     * version degrades to {@code ver=unknown} rather than dropping the hop.
+     */
+    static String hop(String version, String platform) {
+        String ver = sanitizeParam(version);
+        String plat = sanitizeParam(platform == null ? null : platform.toLowerCase(Locale.ROOT));
+
+        StringBuilder hop = new StringBuilder("client=").append(CLIENT_TOKEN);
+        hop.append(";ver=").append(ver.isEmpty() ? UNKNOWN_VERSION : ver);
+        if (!plat.isEmpty()) {
+            hop.append(";plat=").append(plat);
+        }
+        return hop.toString();
+    }
+
+    /**
+     * The driver version as recorded in the JAR manifest, or null when the
+     * driver runs from a plain class directory (tests, IDE runs) and there is no
+     * manifest to read.
+     */
+    static String driverVersion() {
+        Package pkg = ClientHeader.class.getPackage();
+        return pkg == null ? null : pkg.getImplementationVersion();
+    }
+
+    /**
+     * Makes a caller-supplied chain safe to send: drops characters that could
+     * corrupt the grammar or inject a header, normalizes whitespace, and removes
+     * empty hops. A chain that cannot fit in the header at all yields an empty
+     * string.
+     */
+    static String sanitizeChain(String chain) {
+        if (chain == null) {
+            return "";
+        }
+
+        String cleaned = UNSAFE_CHAIN_CHARS.matcher(chain).replaceAll("_");
+        List<String> hops = new ArrayList<>();
+        for (String hop : cleaned.split(",")) {
+            String normalized = REPEATED_WHITESPACE.matcher(hop).replaceAll(" ").trim();
+            if (!normalized.isEmpty()) {
+                hops.add(normalized);
+            }
+        }
+
+        String joined = String.join(", ", hops);
+        return utf8Length(joined) > MAX_HEADER_BYTES ? "" : joined;
+    }
+
+    private static String sanitizeParam(String value) {
+        if (value == null) {
+            return "";
+        }
+        String sanitized = UNSAFE_PARAM_CHARS.matcher(value.trim()).replaceAll("-");
+        // Leading/trailing separators carry no information and read as noise.
+        sanitized = sanitized.replaceAll("^-+", "").replaceAll("-+$", "");
+        return sanitized.length() > MAX_PARAM_LENGTH
+                ? sanitized.substring(0, MAX_PARAM_LENGTH)
+                : sanitized;
+    }
+
+    private static int utf8Length(String value) {
+        return value.getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/lib/src/main/java/com/wherobots/db/jdbc/ClientHeader.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/ClientHeader.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
 /**
@@ -79,10 +80,12 @@ public final class ClientHeader {
      * Returns a copy of {@code headers} carrying a well-formed
      * {@code X-Wherobots-Client} value.
      * <p>
-     * Any existing entry for the header — matched case-insensitively, since HTTP
-     * header names are case-insensitive — is treated as the upstream chain and
-     * collapsed into the canonical key, so the request carries exactly one such
-     * header with this driver's hop appended on the right.
+     * Any existing entries for the header — matched case-insensitively, since
+     * HTTP header names are case-insensitive — are treated as the upstream
+     * chain and collapsed into the canonical key, so the request carries
+     * exactly one such header with this driver's hop appended on the right.
+     * Several case-variant spellings are joined rather than deduplicated: none
+     * of their provenance is dropped.
      * </p>
      *
      * @param headers the outgoing headers; may be null or immutable, and is
@@ -91,17 +94,24 @@ public final class ClientHeader {
      */
     public static Map<String, String> withHop(Map<String, String> headers) {
         Map<String, String> result = new LinkedHashMap<>();
-        String upstream = null;
+        // A Map keyed by String can hold several case-variant spellings of a
+        // header name even though HTTP treats them as one. Keeping only the
+        // last match would silently drop the others' hops, so they are joined
+        // in encounter order -- collapsing to the canonical key without losing
+        // any provenance on the way.
+        StringJoiner upstream = new StringJoiner(", ");
         if (headers != null) {
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 if (entry.getKey() != null && entry.getKey().equalsIgnoreCase(HEADER_NAME)) {
-                    upstream = entry.getValue();
+                    if (entry.getValue() != null && !entry.getValue().isBlank()) {
+                        upstream.add(entry.getValue());
+                    }
                     continue;
                 }
                 result.put(entry.getKey(), entry.getValue());
             }
         }
-        result.put(HEADER_NAME, value(upstream));
+        result.put(HEADER_NAME, value(upstream.length() == 0 ? null : upstream.toString()));
         return result;
     }
 

--- a/lib/src/main/java/com/wherobots/db/jdbc/WherobotsJdbcDriver.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/WherobotsJdbcDriver.java
@@ -55,6 +55,18 @@ public class WherobotsJdbcDriver implements Driver {
     public static final String SHUTDOWN_AFTER_INACTIVE_SECONDS_PROP = "shutdownAfterInactiveSeconds";
     public static final String WS_URI_PROP = "wsUri";
 
+    /**
+     * An optional upstream {@code X-Wherobots-Client} chain to attribute this
+     * connection to. Set it only when the driver is embedded in another
+     * Wherobots client that already received or produced a chain; the driver
+     * appends its own {@code client=jdbc} hop to the right of it. The value is
+     * sanitized and dropped entirely if it would make the header exceed its
+     * size bound. This is advisory telemetry and never affects authentication.
+     *
+     * @see ClientHeader
+     */
+    public static final String CLIENT_CHAIN_PROP = "clientChain";
+
     // Results format; one of {@link DataFormat}
     public static final String FORMAT_PROP = "format";
 
@@ -80,6 +92,22 @@ public class WherobotsJdbcDriver implements Driver {
         String userAgent = String.format("wherobots-jdbc-driver/%s os/%s java/%s",
                 packageVersion, osName, javaVersion);
         return Map.of("User-Agent", userAgent);
+    }
+
+    /**
+     * Carries the caller-supplied upstream client chain, if any, into the
+     * outgoing headers. The driver's own hop is appended to it — and the value
+     * is sanitized — when the session request headers are built, so an absent
+     * or blank property simply yields no upstream chain.
+     *
+     * @see ClientHeader#withHop(Map)
+     */
+    Map<String, String> getClientChainHeader(Properties info) {
+        String chain = info.getProperty(CLIENT_CHAIN_PROP);
+        if (StringUtils.isBlank(chain)) {
+            return Collections.emptyMap();
+        }
+        return Map.of(ClientHeader.HEADER_NAME, chain);
     }
 
     @Override
@@ -129,6 +157,7 @@ public class WherobotsJdbcDriver implements Driver {
 
         Map<String, String> headers = new HashMap<>(getAuthHeaders(info));
         headers.putAll(getUserAgentHeader());
+        headers.putAll(getClientChainHeader(info));
         WherobotsSession session;
 
         String wsUriString = info.getProperty(WS_URI_PROP);

--- a/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
@@ -83,6 +83,11 @@ public abstract class WherobotsSessionSupplier {
         // here, so every request built below — the session creation POST, the
         // session polling GETs, and the WebSocket upgrade — carries it.
         Map<String, String> requestHeaders = ClientHeader.withHop(headers);
+        // Without this, the only way to see what attribution actually went out
+        // is a packet capture. The chain is advisory, client-asserted metadata
+        // — no credentials pass through it — so it is safe to log.
+        logger.debug("{}: {}", ClientHeader.HEADER_NAME,
+                requestHeaders.get(ClientHeader.HEADER_NAME));
 
         HttpClient client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)

--- a/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
+++ b/lib/src/main/java/com/wherobots/db/jdbc/session/WherobotsSessionSupplier.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.wherobots.db.AppStatus;
 import com.wherobots.db.SessionType;
+import com.wherobots.db.jdbc.ClientHeader;
 import com.wherobots.db.jdbc.serde.JsonUtil;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.core.functions.CheckedSupplier;
@@ -78,6 +79,11 @@ public abstract class WherobotsSessionSupplier {
                                           boolean forceNew, Integer shutdownAfterInactiveSeconds,
                                           Map<String, String> headers)
         throws SQLException {
+        // Append this driver's hop to the shared X-Wherobots-Client chain once,
+        // here, so every request built below — the session creation POST, the
+        // session polling GETs, and the WebSocket upgrade — carries it.
+        Map<String, String> requestHeaders = ClientHeader.withHop(headers);
+
         HttpClient client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .build();
@@ -91,9 +97,9 @@ public abstract class WherobotsSessionSupplier {
         Retry retry = RetryRegistry.of(config).retry("session");
 
         try {
-            URI sessionIdUri = new SqlSessionSupplier(client, headers, host, runtime, region, version, sessionType, forceNew, shutdownAfterInactiveSeconds).get();
-            URI wsUri = Retry.decorateCheckedSupplier(retry, new SessionWsUriSupplier(client, headers, sessionIdUri)).get();
-            return create(wsUri, headers);
+            URI sessionIdUri = new SqlSessionSupplier(client, requestHeaders, host, runtime, region, version, sessionType, forceNew, shutdownAfterInactiveSeconds).get();
+            URI wsUri = Retry.decorateCheckedSupplier(retry, new SessionWsUriSupplier(client, requestHeaders, sessionIdUri)).get();
+            return connect(wsUri, requestHeaders);
         } catch (SQLException e) {
             throw e;
         } catch (Throwable t) {
@@ -110,6 +116,15 @@ public abstract class WherobotsSessionSupplier {
      * @throws SQLException
      */
     public static WherobotsSession create(URI wsUri, Map<String, String> headers)
+            throws SQLException {
+        return connect(wsUri, ClientHeader.withHop(headers));
+    }
+
+    /**
+     * Opens the session WebSocket with headers that already carry this driver's
+     * attribution hop.
+     */
+    private static WherobotsSession connect(URI wsUri, Map<String, String> headers)
             throws SQLException {
         logger.info("Connecting to SQL Session at {} ...", wsUri);
         try {

--- a/lib/src/test/java/com/wherobots/db/jdbc/ClientHeaderTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/ClientHeaderTest.java
@@ -69,6 +69,18 @@ class ClientHeaderTest {
     }
 
     @Test
+    void hopTruncationDoesNotExposeATrailingSeparator() {
+        // The 63-character cut lands right after the `,` that sanitizing
+        // turned into a `-`, so stripping separators before truncating is not
+        // enough -- the truncation itself can create a new trailing one.
+        String version = "v".repeat(62) + ",rc1";
+
+        String hop = ClientHeader.hop(version, "linux");
+
+        assertEquals("client=jdbc;ver=" + "v".repeat(62) + ";plat=linux", hop);
+    }
+
+    @Test
     void valueWithoutUpstreamChainIsASingleHop() {
         System.setProperty("os.name", "Linux");
         String value = ClientHeader.value(null);

--- a/lib/src/test/java/com/wherobots/db/jdbc/ClientHeaderTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/ClientHeaderTest.java
@@ -1,0 +1,196 @@
+package com.wherobots.db.jdbc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientHeaderTest {
+
+    private final String originalOsName = System.getProperty("os.name");
+
+    @AfterEach
+    void restoreOsName() {
+        if (originalOsName == null) {
+            System.clearProperty("os.name");
+        } else {
+            System.setProperty("os.name", originalOsName);
+        }
+    }
+
+    private static int utf8Length(String value) {
+        return value.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    @Test
+    void hopRendersTokenVersionAndPlatform() {
+        assertEquals("client=jdbc;ver=0.4.0;plat=mac-os-x",
+                ClientHeader.hop("0.4.0", "Mac OS X"));
+    }
+
+    @Test
+    void hopDegradesToUnknownVersionWhenUnavailable() {
+        // No JAR manifest (IDE / test / shaded-into-an-uber-jar runs) means no
+        // Implementation-Version: the hop is still emitted and well-formed.
+        assertEquals("client=jdbc;ver=unknown;plat=linux", ClientHeader.hop(null, "Linux"));
+        assertEquals("client=jdbc;ver=unknown;plat=linux", ClientHeader.hop("   ", "Linux"));
+    }
+
+    @Test
+    void hopOmitsPlatformWhenUnavailable() {
+        assertEquals("client=jdbc;ver=0.4.0", ClientHeader.hop("0.4.0", null));
+        assertEquals("client=jdbc;ver=0.4.0", ClientHeader.hop("0.4.0", ""));
+    }
+
+    @Test
+    void hopSanitizesGrammarDelimitersOutOfParameters() {
+        String hop = ClientHeader.hop("1.0;cmd=evil,client=spoofed", "li;nux");
+        assertEquals("client=jdbc;ver=1.0-cmd-evil-client-spoofed;plat=li-nux", hop);
+        // Exactly one hop, with only the delimiters we rendered ourselves.
+        assertFalse(hop.contains(","));
+        assertEquals(2, hop.chars().filter(c -> c == ';').count());
+    }
+
+    @Test
+    void hopBoundsParameterLength() {
+        String hop = ClientHeader.hop("v".repeat(200), "p".repeat(200));
+        for (String param : hop.split(";")) {
+            assertTrue(param.split("=", 2)[1].length() < 64,
+                    "token must stay under 64 characters: " + param);
+        }
+    }
+
+    @Test
+    void valueWithoutUpstreamChainIsASingleHop() {
+        System.setProperty("os.name", "Linux");
+        String value = ClientHeader.value(null);
+        assertFalse(value.contains(","), "an origin request emits exactly one hop");
+        assertTrue(value.startsWith("client=jdbc;ver="), value);
+        assertTrue(value.endsWith(";plat=linux"), value);
+    }
+
+    @Test
+    void valueUsesTheManifestVersionWhenAvailable() {
+        // Tests run from a class directory, so there is no manifest to read and
+        // the graceful-degradation path is the one exercised end to end.
+        String expectedVersion = ClientHeader.driverVersion();
+        String expected = expectedVersion == null || expectedVersion.isBlank()
+                ? ClientHeader.UNKNOWN_VERSION
+                : expectedVersion;
+        assertTrue(ClientHeader.value(null).contains(";ver=" + expected),
+                ClientHeader.value(null));
+    }
+
+    @Test
+    void valueAppendsOwnHopToTheRightOfAnUpstreamChain() {
+        System.setProperty("os.name", "Linux");
+        String value = ClientHeader.value("client=claude_web, client=mcp;ver=0.9");
+        assertEquals("client=claude_web, client=mcp;ver=0.9, "
+                + ClientHeader.hop(ClientHeader.driverVersion(), "Linux"), value);
+        // Leftmost hop stays the origin; ours is the rightmost, direct caller.
+        assertTrue(value.startsWith("client=claude_web,"), value);
+        assertTrue(value.endsWith("plat=linux"), value);
+    }
+
+    @Test
+    void valueNormalizesUpstreamChainSpacingAndEmptyHops() {
+        System.setProperty("os.name", "Linux");
+        String value = ClientHeader.value("  client=cli;ver=1.2.0 ,, ,  client=mcp  ");
+        assertTrue(value.startsWith("client=cli;ver=1.2.0, client=mcp, client=jdbc;"), value);
+    }
+
+    @Test
+    void valueStripsCharactersThatWouldInjectAHeaderOrCorruptTheGrammar() {
+        String value = ClientHeader.value("client=cli\r\nX-Evil: 1\ttab\"quote\"");
+        assertFalse(value.contains("\r"), value);
+        assertFalse(value.contains("\n"), value);
+        assertFalse(value.contains("\t"), value);
+        assertFalse(value.contains("\""), value);
+        assertTrue(value.startsWith("client=cli_"), value);
+    }
+
+    @Test
+    void valueDropsAnUpstreamChainThatWouldBreakTheSizeBound() {
+        System.setProperty("os.name", "Linux");
+        String oversized = ("client=" + "x".repeat(40) + ", ").repeat(20);
+        assertTrue(utf8Length(oversized) > ClientHeader.MAX_HEADER_BYTES);
+
+        String value = ClientHeader.value(oversized);
+        assertEquals(ClientHeader.hop(ClientHeader.driverVersion(), "Linux"), value);
+        assertTrue(utf8Length(value) <= ClientHeader.MAX_HEADER_BYTES);
+    }
+
+    @Test
+    void valueSanitizesNonAsciiBeforeMeasuringTheBound() {
+        // Sanitization runs first, so the emitted value is always ASCII and its
+        // byte length is what the bound is measured against.
+        String value = ClientHeader.value("client=" + "é".repeat(600));
+        assertTrue(utf8Length(value) <= ClientHeader.MAX_HEADER_BYTES);
+        assertEquals(value.length(), utf8Length(value));
+        assertTrue(value.startsWith("client=jdbc;"), value);
+    }
+
+    @Test
+    void withHopSetsTheHeaderAndPreservesOtherHeaders() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("X-API-Key", "secret");
+        headers.put("User-Agent", "wherobots-jdbc-driver/0.4.0");
+
+        Map<String, String> result = ClientHeader.withHop(headers);
+
+        assertEquals("secret", result.get("X-API-Key"));
+        assertEquals("wherobots-jdbc-driver/0.4.0", result.get("User-Agent"));
+        assertTrue(result.get(ClientHeader.HEADER_NAME).startsWith("client=jdbc;ver="));
+        // The caller's map is left untouched.
+        assertFalse(headers.containsKey(ClientHeader.HEADER_NAME));
+    }
+
+    @Test
+    void withHopAppendsToADifferentlyCasedExistingHeader() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-wherobots-client", "client=cli;ver=1.2.0");
+
+        Map<String, String> result = ClientHeader.withHop(headers);
+
+        // Exactly one attribution header, under the canonical name.
+        assertEquals(1, result.keySet().stream()
+                .filter(key -> key.equalsIgnoreCase(ClientHeader.HEADER_NAME))
+                .count());
+        assertTrue(result.get(ClientHeader.HEADER_NAME)
+                .startsWith("client=cli;ver=1.2.0, client=jdbc;"),
+                result.get(ClientHeader.HEADER_NAME));
+    }
+
+    @Test
+    void headersAreAcceptedByTheHttpRequestBuilder() {
+        // java.net.http rejects illegal header values outright, so this also
+        // proves a hostile clientChain can never break session creation.
+        Map<String, String> headers = ClientHeader.withHop(
+                Map.of(ClientHeader.HEADER_NAME, "client=cli\r\nX-Evil: 1"));
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create("https://api.example.com/sql/session"));
+        headers.forEach(builder::header);
+        HttpRequest request = builder.build();
+
+        String value = request.headers().firstValue(ClientHeader.HEADER_NAME).orElseThrow();
+        assertTrue(value.contains("client=jdbc;ver="), value);
+    }
+
+    @Test
+    void withHopHandlesNullAndImmutableHeaderMaps() {
+        assertTrue(ClientHeader.withHop(null).get(ClientHeader.HEADER_NAME)
+                .startsWith("client=jdbc;"));
+        assertTrue(ClientHeader.withHop(Map.of("X-API-Key", "secret"))
+                .get(ClientHeader.HEADER_NAME).startsWith("client=jdbc;"));
+    }
+}

--- a/lib/src/test/java/com/wherobots/db/jdbc/ClientHeaderTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/ClientHeaderTest.java
@@ -182,6 +182,25 @@ class ClientHeaderTest {
     }
 
     @Test
+    void withHopKeepsEveryCaseVariantSpellingOfTheHeader() {
+        // A Map<String, String> permits both spellings even though HTTP does
+        // not. No caller produces this today, but collapsing to the last one
+        // seen would silently drop `client=a`.
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-wherobots-client", "client=a");
+        headers.put("X-Wherobots-Client", "client=b");
+
+        Map<String, String> result = ClientHeader.withHop(headers);
+
+        assertEquals(1, result.keySet().stream()
+                .filter(key -> key.equalsIgnoreCase(ClientHeader.HEADER_NAME))
+                .count());
+        assertTrue(result.get(ClientHeader.HEADER_NAME)
+                .startsWith("client=a, client=b, client=jdbc;"),
+                result.get(ClientHeader.HEADER_NAME));
+    }
+
+    @Test
     void headersAreAcceptedByTheHttpRequestBuilder() {
         // java.net.http rejects illegal header values outright, so this also
         // proves a hostile clientChain can never break session creation.

--- a/lib/src/test/java/com/wherobots/db/jdbc/WherobotsJdbcDriverTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/WherobotsJdbcDriverTest.java
@@ -1,6 +1,7 @@
 package com.wherobots.db.jdbc;
 
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -11,6 +12,25 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WherobotsJdbcDriverTest {
+
+    // These tests overwrite JVM-wide system properties, so they restore them
+    // afterwards rather than leaving them set for whatever runs next. Nothing
+    // depends on that today only because every test that reads them sets them
+    // first; test ordering or parallel execution would end that.
+    private final Map<String, String> originalProperties = Map.of(
+            "os.name", System.getProperty("os.name", ""),
+            "java.version", System.getProperty("java.version", ""));
+
+    @AfterEach
+    void restoreSystemProperties() {
+        originalProperties.forEach((key, value) -> {
+            if (value.isEmpty()) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, value);
+            }
+        });
+    }
 
     @Test
     void getUserAgentHeader() {

--- a/lib/src/test/java/com/wherobots/db/jdbc/WherobotsJdbcDriverTest.java
+++ b/lib/src/test/java/com/wherobots/db/jdbc/WherobotsJdbcDriverTest.java
@@ -4,6 +4,11 @@ package com.wherobots.db.jdbc;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WherobotsJdbcDriverTest {
 
@@ -16,5 +21,54 @@ class WherobotsJdbcDriverTest {
         assert header.containsKey("User-Agent");
         String user_agent = header.get("User-Agent");
         assert user_agent.equals("wherobots-jdbc-driver/unknown os/os1 java/1");
+    }
+
+    @Test
+    void getClientChainHeaderIsEmptyWithoutTheProperty() {
+        WherobotsJdbcDriver driver = new WherobotsJdbcDriver();
+        assertTrue(driver.getClientChainHeader(new Properties()).isEmpty());
+
+        Properties blank = new Properties();
+        blank.put(WherobotsJdbcDriver.CLIENT_CHAIN_PROP, "  ");
+        assertTrue(driver.getClientChainHeader(blank).isEmpty());
+    }
+
+    @Test
+    void getClientChainHeaderCarriesTheUpstreamChain() {
+        Properties info = new Properties();
+        info.put(WherobotsJdbcDriver.CLIENT_CHAIN_PROP, "client=cli;ver=1.2.0");
+
+        Map<String, String> header = new WherobotsJdbcDriver().getClientChainHeader(info);
+        assertEquals("client=cli;ver=1.2.0", header.get(ClientHeader.HEADER_NAME));
+    }
+
+    @Test
+    void clientChainPropertyEndsUpLeftOfTheDriverHop() {
+        System.setProperty("os.name", "Linux");
+        Properties info = new Properties();
+        info.put(WherobotsJdbcDriver.CLIENT_CHAIN_PROP, "client=claude_web, client=mcp;ver=0.9");
+
+        // The value the session request will actually carry: the driver stages
+        // the caller's chain, the session supplier appends the driver's hop.
+        Map<String, String> headers = ClientHeader.withHop(
+                new WherobotsJdbcDriver().getClientChainHeader(info));
+
+        assertEquals("client=claude_web, client=mcp;ver=0.9, client=jdbc;ver="
+                        + ClientHeader.UNKNOWN_VERSION + ";plat=linux",
+                headers.get(ClientHeader.HEADER_NAME));
+    }
+
+    @Test
+    void clientChainPropertyCannotInjectAnotherHeader() {
+        Properties info = new Properties();
+        info.put(WherobotsJdbcDriver.CLIENT_CHAIN_PROP, "client=cli\r\nAuthorization: Bearer evil");
+
+        Map<String, String> headers = ClientHeader.withHop(
+                new WherobotsJdbcDriver().getClientChainHeader(info));
+
+        assertEquals(1, headers.size());
+        String value = headers.get(ClientHeader.HEADER_NAME);
+        assertFalse(value.contains("\r"), value);
+        assertFalse(value.contains("\n"), value);
     }
 }


### PR DESCRIPTION
## Summary

The JDBC driver had zero references to `X-Wherobots-Client`, so every Java and BI-tool request (DataGrip, DBeaver, JDBC-backed services) landed in prod attributed as `unknown`. This adds the header.

Every outgoing request now carries `client=jdbc;ver=<driver version>;plat=<os name>`, e.g.

```
X-Wherobots-Client: client=jdbc;ver=0.4.0;plat=mac-os-x
```

Follows the contract in studio-backend's `docs/client-attribution.md`: comma-separated hops, leftmost is the origin, append on the right, 512-byte bound, advisory only and never an input to auth.

## Changes

- **`ClientHeader`** (new) renders the driver's hop and appends it to the right of any upstream chain. The version comes from the JAR manifest (`Implementation-Version`) and degrades to `ver=unknown` when there is no manifest, so the hop is always well formed; `plat` is dropped rather than faked when `os.name` is unavailable.
- **Wired in at `WherobotsSessionSupplier.create()`**, the single place every request originates, so the session-creation POST, the session-polling GETs and the WebSocket upgrade are all covered instead of individual call sites. Both public `create()` overloads go through it, so library callers that bypass the `Driver` are covered too.
- **New `clientChain` connection property** lets a caller embedding the driver supply an upstream chain to prepend (`client=claude_web, client=mcp;ver=0.9, client=jdbc;ver=0.4.0;plat=linux`). It is sanitized before it goes out: characters that would corrupt the hop grammar or inject a header (CR/LF, tabs, quotes) are replaced, empty hops are dropped, and a chain that would push the value past 512 UTF-8 bytes is dropped whole rather than truncated, since a truncated chain is unparseable and an oversized header is discarded wholesale by the backend parser. A bad `clientChain` degrades to a plain single-hop header, never a failed connection.
- README documents the header and the new property.

Matches the already-merged implementations in `wherobots-cli` (Go), `vs-code-extension` (TS) and `wherobots-python-dbapi` (Python).

## Testing

`./gradlew clean build shadowJar --rerun-tasks` on the JDK 17 toolchain: **BUILD SUCCESSFUL**, 44 tests, 0 failures (the 6 skipped are the pre-existing `WherobotsResultSetTest` cases that need `WHEROBOTS_API_KEY`). `./gradlew javadoc` is clean for the new file.

21 new/updated JUnit tests covering:

- exact hop format, and the `HttpRequest.Builder` accepting the rendered value (`java.net.http` rejects illegal header values outright, so this also proves a hostile chain can't break session creation)
- graceful degradation: no manifest → `ver=unknown`; no `os.name` → `plat` omitted
- the `clientChain` append case, including case-insensitive collapse of an existing header key
- sanitization: grammar delimiters inside params, CRLF header injection, empty hops, non-ASCII
- the 512-byte bound, including that the driver's own hop always survives

Verified against the real built JAR (not just the class directory) so the manifest-version path is exercised end to end:

```
$ java -cp wherobots-jdbc-driver-0.4.0.jar:. Probe
origin  : client=jdbc;ver=0.4.0;plat=mac-os-x
chained : client=claude_web, client=mcp;ver=0.9, client=jdbc;ver=0.4.0;plat=mac-os-x
headers : {X-API-Key=secret, X-Wherobots-Client=client=jdbc;ver=0.4.0;plat=mac-os-x}
```

No live session was created against staging or prod as part of this change.

## Follow-up

`jdbc` is not yet in the canonical token vocabulary table in studio-backend's `docs/client-attribution.md`. No backend change is needed to record it (the parser is value-agnostic), but the table should get a row in a separate studio-backend PR.

## Linear

https://linear.app/wherobots/issue/WBC-820

<sub>- from Claude with ❤️</sub>
