### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 description = 'JDBC driver for the Wherobots Cloud Spatial SQL API'
 group = 'com.wherobots.jdbc'
-version = '0.4.0'
+version = '0.5.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Bumps `version` in `lib/build.gradle` from `0.4.0` to `0.5.0` to release v0.5.0 to Maven Central.

## What's in v0.5.0

Two changes since v0.4.0:

- Accept arbitrary region/runtime strings and make them optional (#26)
- Emit the `X-Wherobots-Client` attribution header (WBC-820, #27)

## The diff

One line, one file:

```diff
-version = '0.4.0'
+version = '0.5.0'
```

`lib/build.gradle` is the only place the driver version is *declared*. The `0.4.0`
strings elsewhere in the tree are not declarations and are deliberately untouched:

- `ClientHeaderTest.java` passes `"0.4.0"` as a literal argument to `ClientHeader.hop(...)`.
  Those are self-consistent fixtures, independent of the build version.
- `README.md` shows `ver=0.4.0` in illustrative sample header output.

At runtime the version comes from the JAR manifest via
`ClientHeader.class.getPackage().getImplementationVersion()`, which Gradle populates from
`project.version` — so bumping this one line is sufficient for the emitted header to report
`0.5.0`.

## Merging this is the entire release trigger — do not tag by hand

`.github/workflows/release.yml` fires on a push to `main` touching the `lib/build.gradle`
path. It extracts the version, **creates the `v0.5.0` tag itself** via `gh release create`,
and publishes to Maven Central.

The workflow **skips the whole release** if `v0.5.0` already exists, so creating the tag
manually would silently suppress the publish. No tag has been created or pushed by this
branch; remote tags still end at `v0.4.0`.

> [!NOTE]
> `CONTRIBUTING.md` still documents the old manual release flow, including step 5
> "Create a git tag and GitHub release for the new version". That is stale — it predates the
> automated workflow added in #24 and now contradicts it. Flagging, not fixing, to keep this
> PR to the version bump.

## Verification

`./gradlew clean build` on JDK 17 (the version release.yml uses): **BUILD SUCCESSFUL**,
52 tests, 0 failures, 0 errors. Artifact builds as `wherobots-jdbc-driver-0.5.0.jar`.